### PR TITLE
Improve: Eliminate abstract requirements from NullAuthenticatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ They heavily rely on the following flow:
 
 This library provides a helper that makes the useless contract methods to do nothing; always return nullish or falsy values.
 
+Now we include **`NullAuthenticatable`** trait on a user model.
+
 ```php
 <?php
 
@@ -124,31 +126,26 @@ use Mpyw\NullAuth\NullAuthenticatable;
 class User extends Model implements Authenticatable
 {
     use NullAuthenticatable;
-
-    /**
-     * Get the name of the unique identifier for the user.
-     *
-     * @return string
-     */
-    public function getAuthIdentifierName()
-    {
-        return $this->getKeyName();
-    }
-
-    /**
-     * Get the unique identifier for the user.
-     *
-     * @return mixed
-     */
-    public function getAuthIdentifier()
-    {
-        return $this->{$this->getKeyName()};
-    }
 }
 ```
 
-You only need to implement **[`getAuthIdentifierName()`]** and **[`getAuthIdentifier()`]** along with **`NullAuthenticatable`** trait,
-but you don't have to worry about anything else.
+Then only **[`getAuthIdentifierName()`]** and **[`getAuthIdentifier()`]** are provided as a valid implementation.
+
+```php
+<?php
+
+$user = User::find(1);
+
+// Minimal implementation for Authenticatable
+var_dump($user->getAuthIdentifierName()); // string(2) "id"
+var_dump($user->getAuthIdentifier());     // int(1)
+
+// Useless implementation for Authenticatable when we don't use StatefulGuard
+var_dump($user->getAuthPassword());       // string(0) ""
+var_dump($user->getRememberTokenName());  // string(0) ""
+var_dump($user->getRememberToken());      // string(0) ""
+$user->setRememberToken('...');           // Does nothing
+```
 
 ### Middleware-based Authentication
 

--- a/src/Concerns/HasEloquentIdentifier.php
+++ b/src/Concerns/HasEloquentIdentifier.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Mpyw\NullAuth\Concerns;
+
+/**
+ * Trait HasEloquentIdentifier
+ *
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
+trait HasEloquentIdentifier
+{
+    /**
+     * Get the name of the unique identifier for the user.
+     *
+     * @return string
+     */
+    public function getAuthIdentifierName()
+    {
+        return $this->getKeyName();
+    }
+
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getAuthIdentifier()
+    {
+        return $this->{$this->getKeyName()};
+    }
+}

--- a/src/Concerns/RequiresIdentifier.php
+++ b/src/Concerns/RequiresIdentifier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mpyw\NullAuth\Concerns;
+
+trait RequiresIdentifier
+{
+    /**
+     * Get the name of the unique identifier for the user.
+     *
+     * @return string
+     */
+    abstract public function getAuthIdentifierName();
+
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return mixed
+     */
+    abstract public function getAuthIdentifier();
+}

--- a/src/GenericNullAuthenticatable.php
+++ b/src/GenericNullAuthenticatable.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Mpyw\NullAuth;
+
+trait GenericNullAuthenticatable
+{
+    use Concerns\RequiresIdentifier;
+
+    /**
+     * Get the password for the user.
+     *
+     * @return string
+     */
+    public function getAuthPassword()
+    {
+        return '';
+    }
+
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * @return string
+     */
+    public function getRememberToken()
+    {
+        return '';
+    }
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param  string $value
+     * @return void
+     */
+    public function setRememberToken($value)
+    {
+    }
+
+    /**
+     * Get the column name for the "remember me" token.
+     *
+     * @return string
+     */
+    public function getRememberTokenName()
+    {
+        return '';
+    }
+}

--- a/src/GenericStrictNullAuthenticatable.php
+++ b/src/GenericStrictNullAuthenticatable.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Mpyw\NullAuth;
+
+use LogicException;
+
+trait GenericStrictNullAuthenticatable
+{
+    use Concerns\RequiresIdentifier;
+
+    /**
+     * Get the password for the user.
+     *
+     * @return string
+     */
+    public function getAuthPassword()
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * @return string
+     */
+    public function getRememberToken()
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param string $value
+     */
+    public function setRememberToken($value)
+    {
+        throw new LogicException('Not implemented');
+    }
+
+    /**
+     * Get the column name for the "remember me" token.
+     *
+     * @return string
+     */
+    public function getRememberTokenName()
+    {
+        throw new LogicException('Not implemented');
+    }
+}

--- a/src/NullAuthenticatable.php
+++ b/src/NullAuthenticatable.php
@@ -4,57 +4,6 @@ namespace Mpyw\NullAuth;
 
 trait NullAuthenticatable
 {
-    /**
-     * Get the name of the unique identifier for the user.
-     *
-     * @return string
-     */
-    abstract public function getAuthIdentifierName();
-
-    /**
-     * Get the unique identifier for the user.
-     *
-     * @return mixed
-     */
-    abstract public function getAuthIdentifier();
-
-    /**
-     * Get the password for the user.
-     *
-     * @return string
-     */
-    public function getAuthPassword()
-    {
-        return '';
-    }
-
-    /**
-     * Get the token value for the "remember me" session.
-     *
-     * @return string
-     */
-    public function getRememberToken()
-    {
-        return '';
-    }
-
-    /**
-     * Set the token value for the "remember me" session.
-     *
-     * @param  string $value
-     * @return void
-     */
-    public function setRememberToken($value)
-    {
-    }
-
-    /**
-     * Get the column name for the "remember me" token.
-     *
-     * @return string
-     */
-    public function getRememberTokenName()
-    {
-        return '';
-    }
+    use GenericNullAuthenticatable,
+        Concerns\HasEloquentIdentifier;
 }

--- a/src/StrictNullAuthenticatable.php
+++ b/src/StrictNullAuthenticatable.php
@@ -2,49 +2,8 @@
 
 namespace Mpyw\NullAuth;
 
-use LogicException;
-
 trait StrictNullAuthenticatable
 {
-    use NullAuthenticatable;
-
-    /**
-     * Get the password for the user.
-     *
-     * @return string
-     */
-    public function getAuthPassword()
-    {
-        throw new LogicException('Not implemented');
-    }
-
-    /**
-     * Get the token value for the "remember me" session.
-     *
-     * @return string
-     */
-    public function getRememberToken()
-    {
-        throw new LogicException('Not implemented');
-    }
-
-    /**
-     * Set the token value for the "remember me" session.
-     *
-     * @param string $value
-     */
-    public function setRememberToken($value)
-    {
-        throw new LogicException('Not implemented');
-    }
-
-    /**
-     * Get the column name for the "remember me" token.
-     *
-     * @return string
-     */
-    public function getRememberTokenName()
-    {
-        throw new LogicException('Not implemented');
-    }
+    use GenericStrictNullAuthenticatable,
+        Concerns\HasEloquentIdentifier;
 }

--- a/tests/Unit/NullAuthenticatableTest.php
+++ b/tests/Unit/NullAuthenticatableTest.php
@@ -37,10 +37,20 @@ class NullAuthenticatableTest extends TestCase
 
         $this->user = new class($this->attributes) extends GenericUser {
             use NullAuthenticatable;
+
+            public function getKeyName()
+            {
+                return 'id';
+            }
         };
 
         $this->strict = new class($this->attributes) extends GenericUser {
             use StrictNullAuthenticatable;
+
+            public function getKeyName()
+            {
+                return 'id';
+            }
         };
     }
 

--- a/tests/Unit/NullGuardTest.php
+++ b/tests/Unit/NullGuardTest.php
@@ -40,11 +40,11 @@ class NullGuardTest extends TestCase
 
     public function testValidate(): void
     {
-        $this->guard = Mockery::spy(NullGuard::class . '[user]');
+        $this->guard = Mockery::mock(NullGuard::class . '[user]');
         $this->assertFalse($this->guard->validate(['email' => 'xxx@example.com', 'password' => 'abc123']));
         $this->guard->shouldNotHaveReceived('user');
 
-        $this->guard = Mockery::spy(NullGuard::class . '[user]');
+        $this->guard = Mockery::mock(NullGuard::class . '[user]');
         $this->assertFalse($this->guard->validate(['email' => 'xxx@example.com', 'password' => 'abc123']));
         $this->guard->shouldNotHaveReceived('user');
     }
@@ -66,12 +66,12 @@ class NullGuardTest extends TestCase
 
     public function testHasUser(): void
     {
-        $this->guard = Mockery::spy(NullGuard::class . '[user]');
+        $this->guard = Mockery::mock(NullGuard::class . '[user]');
         $this->guard->setUser($this->user);
         $this->assertTrue($this->guard->hasUser());
         $this->guard->shouldNotHaveReceived('user');
 
-        $this->guard = Mockery::spy(NullGuard::class . '[user]');
+        $this->guard = Mockery::mock(NullGuard::class . '[user]');
         $this->guard->unsetUser();
         $this->assertFalse($this->guard->hasUser());
         $this->guard->shouldNotHaveReceived('user');


### PR DESCRIPTION
Now we don't have to implement any methods. Just simply include `NullAuthenticatable`.

This bumps to version v1.1.0