### PR TITLE
Feat: Add NoRememberTokenAuthenticatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ Null Guard for Laravel. Designed for Middleware-based authentication and testing
 composer require mpyw/null-auth
 ```
 
+## Features
+
+### `NullAuthenticatable` family
+
+| Trait | ID | Password | Remember Token |
+|:---|:---:|:---:|:---:|
+| `GenericNullAuthenticatable`<br>`GenericStrictNullAuthenticatable` | ❗️ | ❌| ❌|
+| `NullAuthenticatable`<br>`StrictNullAuthenticatable` | ✅| ❌| ❌|
+| `NoRememberTokenAuthenticatable`<br>`StrictNoRememberTokenAuthenticatable` | ✅| ✅| ❌|
+
+- ❗️shows containing abstract methods.
+- `Strict` classes throw `LogicException` on bad function calls.
+
+### `NullGuard`
+
+- `NullGuard::user()` always returns Authenticatable already set by `NullGuard::setUser()`.
+- `NullGuard::unsetUser()` can unset user.
+
+### `NullUserProvider`
+
+- All methods do nothing and always returns falsy value.
+
 ## Usage
 
 ### Basic Usage

--- a/src/Concerns/HasEloquentPassword.php
+++ b/src/Concerns/HasEloquentPassword.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mpyw\NullAuth\Concerns;
+
+/**
+ * Trait HasEloquentPassword
+ *
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
+trait HasEloquentPassword
+{
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getAuthPassword()
+    {
+        return $this->getAttribute('password');
+    }
+}

--- a/src/NoRememberTokenAuthenticatable.php
+++ b/src/NoRememberTokenAuthenticatable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mpyw\NullAuth;
+
+use Mpyw\NullAuth\Concerns\HasEloquentPassword;
+
+trait NoRememberTokenAuthenticatable
+{
+    use NullAuthenticatable,
+        HasEloquentPassword {
+        HasEloquentPassword::getAuthPassword insteadof NullAuthenticatable;
+    }
+}

--- a/src/StrictNoRememberTokenAuthenticatable.php
+++ b/src/StrictNoRememberTokenAuthenticatable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mpyw\NullAuth;
+
+use Mpyw\NullAuth\Concerns\HasEloquentPassword;
+
+trait StrictNoRememberTokenAuthenticatable
+{
+    use StrictNullAuthenticatable,
+        HasEloquentPassword {
+        HasEloquentPassword::getAuthPassword insteadof StrictNullAuthenticatable;
+    }
+}

--- a/tests/Unit/NoRememberTokenAuthenticatableTest.php
+++ b/tests/Unit/NoRememberTokenAuthenticatableTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Mpyw\NullAuth\Tests\Unit;
+
+use Illuminate\Auth\GenericUser;
+use LogicException;
+use Mpyw\NullAuth\NoRememberTokenAuthenticatable;
+use Mpyw\NullAuth\StrictNoRememberTokenAuthenticatable;
+use Mpyw\NullAuth\Tests\TestCase;
+
+class NoRememberTokenAuthenticatableTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    protected $attributes;
+
+    /**
+     * @var \Illuminate\Auth\GenericUser|\Mpyw\NullAuth\NoRememberTokenAuthenticatable
+     */
+    protected $user;
+
+    /**
+     * @var \Illuminate\Auth\GenericUser|\Mpyw\NullAuth\NoRememberTokenAuthenticatable
+     */
+    protected $strict;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->attributes = [
+            'id' => 123,
+            'password' => 'foo',
+            'remember_token' => 'xxx',
+        ];
+
+        $this->user = new class($this->attributes) extends GenericUser {
+            use NoRememberTokenAuthenticatable;
+
+            public function getKeyName()
+            {
+                return 'id';
+            }
+
+            public function getAttribute(string $key)
+            {
+                return $this->attributes[$key];
+            }
+        };
+
+        $this->strict = new class($this->attributes) extends GenericUser {
+            use StrictNoRememberTokenAuthenticatable;
+
+            public function getKeyName()
+            {
+                return 'id';
+            }
+
+            public function getAttribute(string $key)
+            {
+                return $this->attributes[$key];
+            }
+        };
+    }
+
+    public function testGetAuthIdentifierName(): void
+    {
+        $this->assertSame('id', $this->user->getAuthIdentifierName());
+        $this->assertSame('id', $this->strict->getAuthIdentifierName());
+    }
+
+    public function testGetAuthIdentifier(): void
+    {
+        $this->assertSame(123, $this->user->getAuthIdentifier());
+        $this->assertSame(123, $this->strict->getAuthIdentifier());
+    }
+
+    public function testGetAuthPassword(): void
+    {
+        $this->assertSame('foo', $this->user->getAuthPassword());
+        $this->assertSame('foo', $this->strict->getAuthPassword());
+    }
+
+    public function testGetRememberToken(): void
+    {
+        $this->assertSame('', $this->user->getRememberToken());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Not implemented');
+        $this->strict->getRememberToken();
+    }
+
+    public function testSetRememberToken(): void
+    {
+        $this->user->setRememberToken('yyy');
+        $this->assertSame('xxx', $this->user->remember_token);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Not implemented');
+        $this->strict->setRememberToken('yyy');
+    }
+
+    public function testGetRememberTokenName(): void
+    {
+        $this->assertSame('', $this->user->getRememberTokenName());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Not implemented');
+        $this->strict->getRememberTokenName();
+    }
+}


### PR DESCRIPTION

| Trait | ID | Password | Remember Token |
|:---|:---:|:---:|:---:|
| `GenericNullAuthenticatable`<br>`GenericStrictNullAuthenticatable` | ❗️ | ❌| ❌|
| `NullAuthenticatable`<br>`StrictNullAuthenticatable` | ✅| ❌| ❌|
| `NoRememberTokenAuthenticatable`<br>`StrictNoRememberTokenAuthenticatable` | ✅| ✅| ❌|

- ❗️shows containing abstract methods.
- `Strict` classes throw `LogicException` on bad function calls.